### PR TITLE
Implementation of LongMapImpl

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .idea/
 long-map.iml
+target/

--- a/README.md
+++ b/README.md
@@ -4,3 +4,23 @@ Finish development of class LongMapImpl, which implements a map with keys of typ
 * it should not use any known Map implementations; 
 * it should use as less memory as possible and have adequate performance;
 * the main aim is to see your codestyle and teststyle 
+
+**Current implementation has the following complexity:**
+
+| Method          | Complexity by memory | Complexity by time     |
+|-----------------|----------------------|------------------------|
+| put()           | O(1)                 | Best: O(1) Worst: O(N) |
+| get()           | O(1)                 | B: O(1) W: O(N)        |
+| remove()        | O(1)                 | B: O(1) W: O(N)        |
+| isEmpty()       | O(1)                 | O(1)                   |
+| containsKey()   | O(1)                 | B: O(1) W: O(N)        |
+| containsValue() | O(1)                 | O(N)                   |
+| keys()          | O(1)                 | O(N)                   |
+| values()        | O(1)                 | O(N)                   |
+| size()          | O(1)                 | O(1)                   |
+| clear()         | O(1)                 | O(N)                   |
+
+Taking into account that requirement was to use as less memory as possible, all operations has O(1) by memory.
+
+To run JaCoCo code coverage report use command:
+`mvn test jacoco:report`

--- a/README.md
+++ b/README.md
@@ -22,5 +22,10 @@ Finish development of class LongMapImpl, which implements a map with keys of typ
 
 Taking into account that requirement was to use as less memory as possible, all operations has O(1) by memory.
 
+The current implementation may be improved. If the linked list is getting to big in case of collision, it may be replaced with a balanced binary search tree. In this case complexity by time of long operations in worst case will be O(logN).
+
+
 To run JaCoCo code coverage report use command:
 `mvn test jacoco:report`
+
+To see the generated report go `target/site/jacoco/index.html` page 

--- a/pom.xml
+++ b/pom.xml
@@ -41,14 +41,6 @@
                     </execution>
                 </executions>
             </plugin>
-<!--            <plugin>-->
-<!--                <groupId>org.apache.maven.plugins</groupId>-->
-<!--                <artifactId>maven-surefire-plugin</artifactId>-->
-<!--                <version>2.19.1</version>-->
-<!--                <configuration>-->
-<!--                    <testFailureIgnore>true</testFailureIgnore>-->
-<!--                </configuration>-->
-<!--            </plugin>-->
         </plugins>
     </build>
 

--- a/pom.xml
+++ b/pom.xml
@@ -22,6 +22,33 @@
                     <target>1.8</target>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>0.8.10</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>report</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+<!--            <plugin>-->
+<!--                <groupId>org.apache.maven.plugins</groupId>-->
+<!--                <artifactId>maven-surefire-plugin</artifactId>-->
+<!--                <version>2.19.1</version>-->
+<!--                <configuration>-->
+<!--                    <testFailureIgnore>true</testFailureIgnore>-->
+<!--                </configuration>-->
+<!--            </plugin>-->
         </plugins>
     </build>
 

--- a/src/main/java/de/comparus/opensource/longmap/LongMapImpl.java
+++ b/src/main/java/de/comparus/opensource/longmap/LongMapImpl.java
@@ -105,6 +105,11 @@ public class LongMapImpl<V> implements LongMap<V> {
         return null;
     }
 
+    /**
+     * Removes the value from the map by specified key if it exists.
+     * @param key the key
+     * @return the value that was removed or NULL in case there was no value for the specified key
+     */
     @Override
     public V remove(long key) {
         int hash = hash(key);
@@ -130,35 +135,65 @@ public class LongMapImpl<V> implements LongMap<V> {
         return null;
     }
 
+    /**
+     * Returns true if the map contains no key-value pairs
+     * @return true if the map contains no key-value pairs
+     */
     @Override
     public boolean isEmpty() {
         return size == 0;
     }
+
+    /**
+     * Returns true if the map contains mapping for this key
+     * @param key the key
+     * @return true if the map contains mapping for this key
+     */
     @Override
     public boolean containsKey(long key) {
         return get(key) != null;
     }
 
+    /**
+     * Returns true if the map contains the specified value
+     * @param value the value
+     * @return true if the map contains the specified value
+     */
     @Override
     public boolean containsValue(V value) {
         return false;
     }
 
+    /**
+     * Returns an array of keys from the map
+     * @return an array of keys from the map
+     */
     @Override
     public long[] keys() {
         return null;
     }
 
+    /**
+     * Returns an array of values from the map
+     * @return an array of values from the map
+     */
     @Override
     public V[] values() {
         return null;
     }
 
+    /**
+     * Returns the number of key-value pairs
+     * @return the number of key-value pairs
+     */
     @Override
     public long size() {
         return size;
     }
 
+    /**
+     * Removes all key-value pairs from the map
+     */
     @Override
     public void clear() {
         size = 0;

--- a/src/main/java/de/comparus/opensource/longmap/LongMapImpl.java
+++ b/src/main/java/de/comparus/opensource/longmap/LongMapImpl.java
@@ -1,43 +1,164 @@
 package de.comparus.opensource.longmap;
 
+/**
+ * Implementation of a hash table with keys of type long
+ * @param <V> the type of the value
+ */
 public class LongMapImpl<V> implements LongMap<V> {
+
+    /**
+     * The default initial capacity
+     */
+    static final int DEFAULT_INITIAL_CAPACITY = 16;
+
+    /**
+     * A map entry (key-value pair).
+     * @param <V> the type of the value
+     */
+    static class Node<V> {
+        long key;
+        V value;
+        int hash;
+        Node<V> next;
+
+        Node(long key, V value, int hash, Node<V> next) {
+            this.key = key;
+            this.value = value;
+            this.hash = hash;
+            this.next = next;
+        }
+
+        Node(long key, V value, int hash) {
+            this(key, value, hash, null);
+        }
+    }
+
+
+    /**
+     * The table.
+     */
+    Node<V>[] table;
+
+    private long size = 0;
+
+    /**
+     * Ctor.
+     */
+    public LongMapImpl() {
+        // TODO: implement lazy initialization.
+        // TODO: add load factor
+        this.table = (Node<V>[]) new Node[DEFAULT_INITIAL_CAPACITY];
+    }
+
+    /**
+     * Puts the specified value with the specified key into this map. If the map contains a value for this key,
+     * it will be replaced.
+     * @param key the key
+     * @param value the value
+     * @return the previous value specified by the provided key
+     */
+    @Override
     public V put(long key, V value) {
+        //TODO: create only if needed
+        return put(key, value, hash(key));
+    }
+    private V put(long key, V value, int hash) {
+        int pos = position(hash);
+        if (table[pos] == null) {
+            table[pos] = new Node<>(key, value, hash(key));
+            size++;
+            return null;
+        } else {
+            Node<V> parent = null;
+            Node<V> current = table[pos];
+            while (current != null) {
+                if (current.hash == hash && current.key == key) {
+                    V curValue = current.value;
+                    current.value = value;
+                    return curValue;
+                }
+                parent = current;
+                current = current.next;
+            }
+            parent.next = new Node<>(key, value, hash(key));
+            size++;
+        }
         return null;
     }
 
+    /**
+     * Gets the value by the specified key
+     * @param key the key
+     * @return the value by the specified key
+     */
+    @Override
     public V get(long key) {
+        int hash = hash(key);
+        int pos = position(hash);
+        Node<V> current = table[pos];
+        while (current != null) {
+            if (current.hash == hash && current.key == key) {
+                return current.value;
+            }
+            current = current.next;
+        }
         return null;
     }
 
+    @Override
     public V remove(long key) {
         return null;
     }
 
+    @Override
     public boolean isEmpty() {
-        return false;
+        return size == 0;
     }
-
+    @Override
     public boolean containsKey(long key) {
-        return false;
+        return get(key) != null;
     }
 
+    @Override
     public boolean containsValue(V value) {
         return false;
     }
 
+    @Override
     public long[] keys() {
         return null;
     }
 
+    @Override
     public V[] values() {
         return null;
     }
 
+    @Override
     public long size() {
-        return 0;
+        return size;
     }
 
+    @Override
     public void clear() {
 
+    }
+
+    /**
+     * Returns a hash code for the specified long value.
+     * @param val the value to hash
+     * @return the hash code for the specified long value.
+     */
+    int hash(long val) {
+        return Long.hashCode(val);
+    }
+
+    /**
+     * Returns the position in the table for the key by its hash code
+     * @param hash hash code of the key
+     * @return the position in the table for the specified hash code
+     */
+    private int position(int hash) {
+        return hash%(table.length - 1);
     }
 }

--- a/src/main/java/de/comparus/opensource/longmap/LongMapImpl.java
+++ b/src/main/java/de/comparus/opensource/longmap/LongMapImpl.java
@@ -1,11 +1,12 @@
 package de.comparus.opensource.longmap;
 
+import java.lang.reflect.Array;
+
 /**
  * Implementation of a hash table with keys of type long
  * @param <V> the type of the value
  */
 public class LongMapImpl<V> implements LongMap<V> {
-
     /**
      * The default initial capacity
      */
@@ -39,7 +40,7 @@ public class LongMapImpl<V> implements LongMap<V> {
      */
     Node<V>[] table;
 
-    private long size = 0;
+    private int size = 0;
 
     /**
      * Ctor.
@@ -59,7 +60,6 @@ public class LongMapImpl<V> implements LongMap<V> {
      */
     @Override
     public V put(long key, V value) {
-        //TODO: create only if needed
         return put(key, value, hash(key));
     }
     private V put(long key, V value, int hash) {
@@ -161,6 +161,15 @@ public class LongMapImpl<V> implements LongMap<V> {
      */
     @Override
     public boolean containsValue(V value) {
+        for (int i = 0; i < table.length; i++) {
+            if (table[i] != null) {
+                Node<V> current = table[i];
+                while (current != null) {
+                    if (current.value.equals(value)) return true;
+                    current = current.next;
+                }
+            }
+        }
         return false;
     }
 
@@ -170,16 +179,42 @@ public class LongMapImpl<V> implements LongMap<V> {
      */
     @Override
     public long[] keys() {
-        return null;
+        long[] result = new long[size];
+        int counter = 0;
+        for (int i = 0; i < table.length; i++) {
+            if (table[i] != null) {
+                Node<V> current = table[i];
+                while (current != null) {
+                    result[counter] = current.key;
+                    current = current.next;
+                    counter++;
+                }
+            }
+        }
+        return result;
     }
 
     /**
      * Returns an array of values from the map
-     * @return an array of values from the map
+     * @return an array of values from the map or Null in case if map is empty
      */
     @Override
     public V[] values() {
-        return null;
+        if (isEmpty()) return null;
+        V anyVal = findAny();
+        V[] result = (V[]) Array.newInstance(anyVal.getClass(), size);
+        int counter = 0;
+        for (int i = 0; i < table.length; i++) {
+            if (table[i] != null) {
+                Node<V> current = table[i];
+                while (current != null) {
+                    result[counter] = current.value;
+                    current = current.next;
+                    counter++;
+                }
+            }
+        }
+        return result;
     }
 
     /**
@@ -218,5 +253,15 @@ public class LongMapImpl<V> implements LongMap<V> {
      */
     private int position(int hash) {
         return hash%(table.length - 1);
+    }
+
+    private V findAny() {
+        for (int i = 0; i < table.length; i++) {
+            Node<V> current = table[i];
+            if (current != null) {
+                return current.value;
+            }
+        }
+        return null;
     }
 }

--- a/src/main/java/de/comparus/opensource/longmap/LongMapImpl.java
+++ b/src/main/java/de/comparus/opensource/longmap/LongMapImpl.java
@@ -107,6 +107,26 @@ public class LongMapImpl<V> implements LongMap<V> {
 
     @Override
     public V remove(long key) {
+        int hash = hash(key);
+        int pos = position(hash);
+        Node<V> current = table[pos];
+        if (current == null) return null;
+        if (current.hash == hash && current.key == key) {
+            table[pos] = current.next;
+            size--;
+            return current.value;
+        }
+        Node<V> parent = current;
+        current = current.next;
+        while (current != null) {
+            if (current.hash == hash && current.key == key) {
+                parent.next = current.next;
+                size--;
+                return current.value;
+            }
+            parent = current;
+            current = current.next;
+        }
         return null;
     }
 
@@ -141,7 +161,10 @@ public class LongMapImpl<V> implements LongMap<V> {
 
     @Override
     public void clear() {
-
+        size = 0;
+        for (int i = 0; i < table.length; i++) {
+            table[i] = null;
+        }
     }
 
     /**

--- a/src/test/java/de/comparus/opensource/longmap/ConstHashLongMapImpl.java
+++ b/src/test/java/de/comparus/opensource/longmap/ConstHashLongMapImpl.java
@@ -1,0 +1,13 @@
+package de.comparus.opensource.longmap;
+
+/**
+ * ConstHashLongMapImpl extends LongMapImp. It overrides hash method to return some constant value.
+ * @param <V> the type of the value
+ */
+public class ConstHashLongMapImpl<V> extends LongMapImpl<V>{
+
+    @Override
+    int hash(long val) {
+        return 12;
+    }
+}

--- a/src/test/java/de/comparus/opensource/longmap/LongMapImplTest.java
+++ b/src/test/java/de/comparus/opensource/longmap/LongMapImplTest.java
@@ -6,6 +6,7 @@ import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 public class LongMapImplTest {
@@ -19,7 +20,6 @@ public class LongMapImplTest {
 
     @After
     public void clear() {
-        //NB! Not implemented yet.
         map.clear();
     }
 
@@ -33,8 +33,6 @@ public class LongMapImplTest {
     @Test
     public void testPutValue_overridePreviousValue() {
         map.put(KEY_1, VALUE_1);
-        assertEquals(1, map.size());
-        assertEquals(VALUE_1, map.get(KEY_1));
         String prevVal = map.put(KEY_1, VALUE_2);
         assertEquals(1, map.size());
         assertEquals(VALUE_1, prevVal);
@@ -43,26 +41,63 @@ public class LongMapImplTest {
 
     @Test
     public void testPutValue_collision() {
-        LongMap<String> map = new ConstHashLongMapImpl<>();
-        for (long l = 0L; l < 10L; l++) {
-            map.put(l, VALUE_1);
-        }
-        assertEquals(10, map.size());
-        for (long l = 0L; l < 10L; l++) {
+        long count = 5L;
+        LongMap<String> map = prepareMapCollision(count);
+        for (long l = 0L; l < count; l++) {
             assertEquals(VALUE_1, map.get(l));
         }
     }
 
     @Test
-    @Ignore
-    public void testRemoveValue() {
-        //TODO: implement
+    public void testGet_nonExist() {
+        map.put(KEY_1, VALUE_1);
+        assertNull(map.get(KEY_2));
     }
 
     @Test
-    @Ignore
+    public void testGet_emptyMap() {
+        assertNull(map.get(KEY_2));
+    }
+
+    @Test
+    public void testRemoveValue() {
+        map.put(KEY_1, VALUE_1);
+        String removed = map.remove(KEY_1);
+        assertEquals(VALUE_1, removed);
+        assertEquals(0, map.size());
+    }
+
+    @Test
+    public void testRemoveValue_nonExist() {
+        map.put(KEY_1, VALUE_1);
+        String removed = map.remove(KEY_2);
+        assertEquals(1, map.size());
+        assertNull(removed);
+    }
+
+    @Test
+    public void testRemoveValue_emptyMap() {
+        String removed = map.remove(KEY_1);
+        assertNull(removed);
+    }
+
+    @Test
+    public void testRemoveValue_collision_first() {
+        testRemoveValue_collision(5L, 0L);
+    }
+
+    @Test
+    public void testRemoveValue_collision_last() {
+        long count = 5L;
+        testRemoveValue_collision(count, count - 1L);
+    }
+
+
+    @Test
     public void testIsEmpty() {
-        //TODO: implement
+        assertTrue(map.isEmpty());
+        map.put(KEY_1, VALUE_1);
+        assertFalse(map.isEmpty());
     }
 
     @Test
@@ -93,6 +128,23 @@ public class LongMapImplTest {
     @Test
     @Ignore
     public void testResizing() {
+
         //TODO: implement
+    }
+
+    private LongMap<String> prepareMapCollision(long count) {
+        LongMap<String> map = new ConstHashLongMapImpl<>();
+        for (long l = 0L; l < count; l++) {
+            map.put(l, VALUE_1);
+        }
+        assertEquals(count, map.size());
+        return map;
+    }
+
+    private void testRemoveValue_collision(long count, long position) {
+        LongMap<String> map = prepareMapCollision(count);
+        String removed = map.remove(position);
+        assertEquals(VALUE_1, removed);
+        assertEquals((count - 1L), map.size());
     }
 }

--- a/src/test/java/de/comparus/opensource/longmap/LongMapImplTest.java
+++ b/src/test/java/de/comparus/opensource/longmap/LongMapImplTest.java
@@ -1,0 +1,98 @@
+package de.comparus.opensource.longmap;
+
+import org.junit.After;
+import org.junit.Ignore;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class LongMapImplTest {
+    private static final long KEY_1 = 1L;
+    private static final long KEY_2 = 2L;
+    private static final String VALUE_1 = "Value1";
+
+    private static final String VALUE_2 = "Value2";
+
+    private final LongMap<String> map = new LongMapImpl<>();
+
+    @After
+    public void clear() {
+        //NB! Not implemented yet.
+        map.clear();
+    }
+
+    @Test
+    public void testPutGetValue() {
+        map.put(KEY_1, VALUE_1);
+        assertEquals(1, map.size());
+        assertEquals(VALUE_1, map.get(KEY_1));
+    }
+
+    @Test
+    public void testPutValue_overridePreviousValue() {
+        map.put(KEY_1, VALUE_1);
+        assertEquals(1, map.size());
+        assertEquals(VALUE_1, map.get(KEY_1));
+        String prevVal = map.put(KEY_1, VALUE_2);
+        assertEquals(1, map.size());
+        assertEquals(VALUE_1, prevVal);
+        assertEquals(VALUE_2, map.get(KEY_1));
+    }
+
+    @Test
+    public void testPutValue_collision() {
+        LongMap<String> map = new ConstHashLongMapImpl<>();
+        for (long l = 0L; l < 10L; l++) {
+            map.put(l, VALUE_1);
+        }
+        assertEquals(10, map.size());
+        for (long l = 0L; l < 10L; l++) {
+            assertEquals(VALUE_1, map.get(l));
+        }
+    }
+
+    @Test
+    @Ignore
+    public void testRemoveValue() {
+        //TODO: implement
+    }
+
+    @Test
+    @Ignore
+    public void testIsEmpty() {
+        //TODO: implement
+    }
+
+    @Test
+    public void testContainsKey() {
+        map.put(KEY_1, VALUE_1);
+        assertTrue(map.containsKey(KEY_1));
+        assertFalse(map.containsKey(KEY_2));
+    }
+
+    @Test
+    @Ignore
+    public void testContainsValue() {
+        //TODO: implement
+    }
+
+    @Test
+    @Ignore
+    public void testKeys() {
+        //TODO: implement
+    }
+
+    @Test
+    @Ignore
+    public void testValues() {
+        //TODO: implement
+    }
+
+    @Test
+    @Ignore
+    public void testResizing() {
+        //TODO: implement
+    }
+}

--- a/src/test/java/de/comparus/opensource/longmap/LongMapImplTest.java
+++ b/src/test/java/de/comparus/opensource/longmap/LongMapImplTest.java
@@ -4,6 +4,9 @@ import org.junit.After;
 import org.junit.Ignore;
 import org.junit.Test;
 
+import java.util.Arrays;
+
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
@@ -108,21 +111,20 @@ public class LongMapImplTest {
     }
 
     @Test
-    @Ignore
     public void testContainsValue() {
-        //TODO: implement
+        map.put(KEY_1, VALUE_1);
+        assertTrue(map.containsValue(VALUE_1));
+        assertFalse(map.containsValue(VALUE_2));
     }
 
     @Test
-    @Ignore
-    public void testKeys() {
-        //TODO: implement
+    public void testKeysValues() {
+        testKeysValues(map);
     }
 
     @Test
-    @Ignore
-    public void testValues() {
-        //TODO: implement
+    public void testKeysValues_collision() {
+        testKeysValues(new ConstHashLongMapImpl<>());
     }
 
     @Test
@@ -146,5 +148,19 @@ public class LongMapImplTest {
         String removed = map.remove(position);
         assertEquals(VALUE_1, removed);
         assertEquals((count - 1L), map.size());
+    }
+
+    private void testKeysValues(LongMap<String> map) {
+        String[] expectedValues = {"Val1", "Val2", "Val3", "Val4"};
+        long[] expectedKeys = {1L, 23L, 590L, 6734L};
+        for (int i = 0; i < expectedValues.length; i++) {
+            map.put(expectedKeys[i], expectedValues[i]);
+        }
+        String[] actualValues = map.values();
+        Arrays.sort(actualValues);
+        long[] actualKeys = map.keys();
+        Arrays.sort(actualKeys);
+        assertArrayEquals(expectedValues, actualValues);
+        assertArrayEquals(expectedKeys, actualKeys);
     }
 }

--- a/src/test/java/de/comparus/opensource/longmap/LongMapImplTest.java
+++ b/src/test/java/de/comparus/opensource/longmap/LongMapImplTest.java
@@ -1,7 +1,6 @@
 package de.comparus.opensource.longmap;
 
 import org.junit.After;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import java.util.Arrays;
@@ -58,11 +57,6 @@ public class LongMapImplTest {
     }
 
     @Test
-    public void testGet_emptyMap() {
-        assertNull(map.get(KEY_2));
-    }
-
-    @Test
     public void testRemoveValue() {
         map.put(KEY_1, VALUE_1);
         String removed = map.remove(KEY_1);
@@ -79,12 +73,6 @@ public class LongMapImplTest {
     }
 
     @Test
-    public void testRemoveValue_emptyMap() {
-        String removed = map.remove(KEY_1);
-        assertNull(removed);
-    }
-
-    @Test
     public void testRemoveValue_collision_first() {
         testRemoveValue_collision(5L, 0L);
     }
@@ -94,7 +82,6 @@ public class LongMapImplTest {
         long count = 5L;
         testRemoveValue_collision(count, count - 1L);
     }
-
 
     @Test
     public void testIsEmpty() {
@@ -128,10 +115,48 @@ public class LongMapImplTest {
     }
 
     @Test
-    @Ignore
-    public void testResizing() {
+    public void testEmptyMap() {
+        LongMap<String> map = new LongMapImpl<>();
+        map.put(KEY_1, VALUE_1);
+        map.clear();
+        assertNull(map.get(KEY_1));
+        assertNull(map.remove(KEY_1));
+        assertFalse(map.containsKey(KEY_1));
+        assertFalse(map.containsValue(VALUE_2));
+        assertNull(map.keys());
+        assertNull(map.values());
+    }
 
-        //TODO: implement
+    @Test
+    public void testNewMap() {
+        LongMap<String> map = new LongMapImpl<>();
+        assertNull(map.get(KEY_1));
+        assertNull(map.remove(KEY_1));
+        assertFalse(map.containsKey(KEY_1));
+        assertFalse(map.containsValue(VALUE_2));
+        assertNull(map.keys());
+        assertNull(map.values());
+    }
+
+    @Test
+    public void testResizing() {
+        LongMapImpl<String> map = new LongMapImpl<>();
+        // The default threshold is 12. To force resizing at least 13 items should be added.
+        int count = 13;
+
+        long[] expectedKeys = new long[count];
+        // put item to init map
+        map.put(0, VALUE_1);
+        expectedKeys[0] = 0;
+        assertEquals(16, map.table.length);
+        for (int i = 1; i < count; i++) {
+            expectedKeys[i] = i;
+            map.put(i, VALUE_1);
+        }
+        assertEquals(32, map.table.length);
+        long[] actualKeys = map.keys();
+        Arrays.sort(actualKeys);
+        assertArrayEquals(expectedKeys, actualKeys);
     }
 
     private LongMap<String> prepareMapCollision(long count) {


### PR DESCRIPTION
Test task: finished development of class LongMapImpl

Current implementation has the following complexity:
 put(): Memory: O(1); Time: Best: O(1) Worst: O(N) 
 get(): Memory: O(1); Time: B: O(1) W: O(N)
 remove(): Memory: O(1); Time: B: O(1) W: O(N)
Taking into account that requirement was to use as less memory as possible, all operations has O(1) by memory. Other operations are listed in README.

The current implementation may be improved. If the linked list is getting to big in case of collision, it may be replaced with a balanced binary search tree. In this case complexity by time of long operations in worst case will be O(logN).
